### PR TITLE
Rename `run` => `runCommands`

### DIFF
--- a/src/Yii2ssh.php
+++ b/src/Yii2ssh.php
@@ -74,7 +74,7 @@ class Yii2ssh extends Widget
 	 *
 	 * @return string|null
 	 */
-	public function run($commands, $callback = null)
+	public function runCommands($commands, $callback = null)
 	{
 		if (!$this->ssh->isConnected())
 			throw new NotConnectedException();


### PR DESCRIPTION
Fix Exception: Declaration of ourren\yii2ssh\Yii2ssh::run($commands, $callback = NULL) should be compatible with yii\base\Widget::run() in ourren/yii2-ssh2/src/Yii2ssh.php:13